### PR TITLE
Fixes from a test deploy.

### DIFF
--- a/.github/workflows/update-help-dep.yml
+++ b/.github/workflows/update-help-dep.yml
@@ -1,0 +1,10 @@
+
+name: Update Helm Tarball
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  update-helm-deps-tarballs:
+    uses: metal-toolbox/helm-tar-update/.github/workflows/helm-tar-update.yml@main

--- a/Chart.lock
+++ b/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: v0.0.118
-digest: sha256:6258aa726abd1b8995ed0a50ec3ba038440c6a43524b42a35cd8ca6bff87d50c
-generated: "2022-09-12T14:27:52.190614485-06:00"
+digest: sha256:8202515af0e488048bc6a073283542e2a5f260e63fdf038026dffe7a9af26b34
+generated: "2022-09-13T21:34:31.096829425Z"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cockroachdb
-version: 2.1.0
+version: 3.0.0
 appVersion: 22.1.4
 description: Multi-k8s cockroach deployment
 sources:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cockroachdb
-version: 2.0.1
+version: 2.1.0
 appVersion: 22.1.4
 description: Multi-k8s cockroach deployment
 sources:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cockroachdb
-version: 3.0.0
+version: 2.1.0
 appVersion: 22.1.4
 description: Multi-k8s cockroach deployment
 sources:

--- a/templates/application/service.discovery.yaml
+++ b/templates/application/service.discovery.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ template "cockroachdb.fullname" $ }}-{{ $i }}.{{ $.Values.clusterInfo.fqdn }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $.Release.Name }}-{{ $i }}.{{ $.Values.clusterInfo.fqdn }}
 spec:
   publishNotReadyAddresses: true
   type: LoadBalancer

--- a/templates/application/service.discovery.yaml
+++ b/templates/application/service.discovery.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ $.Release.Name }}-{{ $i }}.{{ $.Values.clusterInfo.fqdn }}
+    external-dns.alpha.kubernetes.io/hostname: {{ template "cockroachdb.fullname" $ }}-{{ $i }}.{{ $.Values.clusterInfo.fqdn }}
 spec:
   publishNotReadyAddresses: true
   type: LoadBalancer

--- a/templates/application/statefulset.yaml
+++ b/templates/application/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- with .Values.statefulset.statefulsetAnnotations }}
      {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: {{ template "cockroachdb.name" . }}
+  name: {{ template "cockroachdb.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}

--- a/templates/application/statefulset.yaml
+++ b/templates/application/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- with .Values.statefulset.statefulsetAnnotations }}
      {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: {{ template "cockroachdb.fullname" . }}
+  name: {{ template "cockroachdb.name" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}

--- a/templates/certs/cert-manager/certificate.node.yaml
+++ b/templates/certs/cert-manager/certificate.node.yaml
@@ -37,6 +37,9 @@ spec:
   dnsNames:
     - "localhost"
     - {{ printf "*.%s" .Values.clusterInfo.fqdn | quote }}
+    - {{ printf "%s-internal" (include "cockroachdb.fullname" .) | quote }}
+    - {{ printf "%s-internal.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
+    - {{ printf "%s-internal.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
     - {{ printf "%s-public" (include "cockroachdb.fullname" .) | quote }}
     - {{ printf "%s-public.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
     - {{ printf "%s-public.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,5 @@
 clusterInfo: {}
 
-nameOverride: crdb
-fullnameOverride: crdb
-
 # Generated file, DO NOT EDIT. Source: build/templates/values.yaml
 image:
   repository: cockroachdb/cockroach

--- a/values.yaml
+++ b/values.yaml
@@ -299,8 +299,8 @@ service:
     labels:
       app.kubernetes.io/component: cockroachdb
     # Additional annotations to apply to this Service.
-    annotations:
-      metallb.universe.tf/address-pool: cockroachdb
+    annotations: {}
+    #  metallb.universe.tf/address-pool: custom-ip-pool
 
   internal:
     enabled: true


### PR DESCRIPTION
* Includes the internal service names on the node cert SANs
* better separates discovery URL's to be namespace dependent - helps avoid naming collisions 
* Removes a default metal annotation, suggests it as a comment