### PR TITLE
Fix reloader annotations to reference the matching secrets

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: cockroachdb
-version: 2.4.0
-appVersion: v23.1.8
+version: 2.5.0
+appVersion: v23.1.22
 description: Multi-k8s cockroach deployment
 sources:
   - https://github.com/cockroachdb/cockroach

--- a/templates/application/deployment.toolbox.yaml
+++ b/templates/application/deployment.toolbox.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "cockroachdb.name" . }}-toolbox
   annotations:
     argocd.argoproj.io/sync-wave: '10'
-    secret.reloader.stakater.com/reload: {{ template "cockroachdb.name" . }}-root
+    secret.reloader.stakater.com/reload: {{ template "cockroachdb.fullname" . }}-root
   {{- with .Values.toolbox.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/application/statefulset.yaml
+++ b/templates/application/statefulset.yaml
@@ -2,7 +2,7 @@ kind: StatefulSet
 apiVersion: {{ template "cockroachdb.statefulset.apiVersion" . }}
 metadata:
   annotations:
-    secret.reloader.stakater.com/reload: {{ template "cockroachdb.name" . }}-node
+    secret.reloader.stakater.com/reload: {{ template "cockroachdb.fullname" . }}-node
   {{- with .Values.statefulset.statefulsetAnnotations }}
      {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@ clusterInfo: {}
 
 image:
   repository: cockroachdb/cockroach
-  tag: v23.1.8
+  tag: v23.1.22
   pullPolicy: IfNotPresent
   credentials: {}
     # registry: docker.io


### PR DESCRIPTION
This PR fixes a bug where the reloader annotation did not reference the correct secrets if the chart name was overridden.
Also bumps the default crdb version to v23.1.22