### PR TITLE
support including image pull secrets

### DIFF
--- a/templates/application/serviceaccount.yaml
+++ b/templates/application/serviceaccount.yaml
@@ -12,4 +12,7 @@ metadata:
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.tls.serviceAccount.imagePullSecrets }}
+imagePullSecrets: {{- tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -386,6 +386,8 @@ tls:
     # The name of this ServiceAccount to use.
     # If not set and `create` is `true`, then a name is auto-generated.
     name: ""
+    # Include image pull secret references. (Supports templating)
+    imagePullSecrets: []
   copyCerts:
     image: alpine
   certs:


### PR DESCRIPTION
This allows for the inclusion of image pull secrets in the created ServiceAccount.